### PR TITLE
Fix #6 Role is broken when conda_env_environment is a path to file

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 conda_env_bin_dir: '{{ conda_env_conda_dir }}/bin'
 conda_env_env_ymls: '{{ conda_env_conda_dir }}/env-ymls'
-conda_env_fq_dest_environment: '{{ conda_env_env_ymls }}/{{ conda_env_name }}-{{ conda_env_environment }}'
+conda_env_fq_dest_environment: '{{ conda_env_env_ymls }}/{{ conda_env_name }}-{{ conda_env_environment | basename }}'
 
 conda_env_conda_bin: '{{ conda_env_bin_dir }}/conda'
 


### PR DESCRIPTION
This fixes the #6 issue of role failing when conda_env_environment is a path 