### PR TITLE
allow env creation to be idempotent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: gather conda info
+  command: "{{ conda_env_bin_dir }}/conda info --json"
+  register: conda_info
+  changed_when: False
+
+- set_fact:
+    conda_info: "{{ conda_info.stdout | from_json }}"
+
 - name: mkdir env-ymls
   become: '{{ conda_env_escalate }}'
   become_user: root
@@ -19,6 +27,10 @@
   become: '{{ conda_env_escalate }}'
   become_user: root
   command: '{{ conda_env_bin_dir }}/conda env {{ conda_env_action_command }} -f={{ conda_env_fq_dest_environment }} -q -n {{ conda_env_name }}'
+  args:
+    # pretend task creates nothing to always run when updating an environment. In general, the first directory
+    # is where conda creates new environments.
+    creates: "{% if conda_env_action_command == 'update' %}{% else %}{{ conda_info.envs_dirs | first }}/{{ conda_env_name }}{% endif %}"
 
 - name: addl packages...
   become: '{{ conda_env_escalate }}'


### PR DESCRIPTION
A subsequent run would fail with "CondaValueError: prefix already exists".
