### PR TITLE
replace hard-coded path with conda_env_conda_dir

### DIFF
--- a/templates/activate.sh.j2
+++ b/templates/activate.sh.j2
@@ -1,1 +1,1 @@
-source /usr/local/anaconda/bin/activate {{conda_env_name}}
+source {{ conda_env_conda_dir }}/bin/activate {{conda_env_name}}


### PR DESCRIPTION
Currently `ansible-miniconda` allows one to specify the Conda installation path, but `ansible-conda-env` doesn't respect it due to a hard-coded path.

This PR replaces the hard-coded path with `conda_env_conda_dir`.