### PR TITLE
Allows the use of prefix for install instead of name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,9 @@ conda_env_conda_dir: /usr/local/anaconda
 conda_env_exe: conda
 conda_env_escalate: true
 conda_env_cleanup: false
-# Uncomment to use a prefix instead of name
-# conda_env_prefix:
- 
+# Leave blank to use name, otherwise uses prefix provided for install
+conda_env_prefix:
+
 #conda_env_name: my-fancy-environment
 # the environment.yml file is found via the template module
 #conda_env_environment: environment.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,9 @@ conda_env_conda_dir: /usr/local/anaconda
 conda_env_exe: conda
 conda_env_escalate: true
 conda_env_cleanup: false
-
+# Uncomment to use a prefix instead of name
+# conda_env_prefix:
+ 
 #conda_env_name: my-fancy-environment
 # the environment.yml file is found via the template module
 #conda_env_environment: environment.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: '{{ conda_env_action_command }} the conda environment'
   become: '{{ conda_env_escalate }}'
   become_user: root
-  command: '{{ conda_env_bin_dir }}/mamba env {{ conda_env_action_command }} -f={{ conda_env_fq_dest_environment }} -q -n {{ conda_env_name }}'
+  command: '{{ conda_env_conda_bin }} env {{ conda_env_action_command }} --file={{ conda_env_fq_dest_environment }} -q -n {{ conda_env_name }}'
   args:
     # pretend task creates nothing to always run when updating an environment. In general, the first directory
     # is where conda creates new environments.
@@ -38,13 +38,13 @@
   become_user: root
   when: conda_env_addl_pkgs is defined
   with_items: '{{  conda_env_addl_pkgs | default([])  }}'
-  command: '{{ conda_env_bin_dir }}/mamba install -n {{ conda_env_name }} -yq -c {{  item.c | default("defaults")  }} {{  item.p  }}'
+  command: '{{ conda_env_conda_bin }} install -n {{ conda_env_name }} -yq -c {{  item.c | default("defaults")  }} {{  item.p  }}'
 
-- name: '{{ conda_env_bin_dir }}/mamba clean -tipsyq'
+- name: '{{ conda_env_conda_bin }} clean -tipsyq'
   become: '{{ conda_env_escalate }}'
   become_user: root
   when: conda_env_cleanup
-  command: '{{ conda_env_bin_dir }}/mamba clean -tipsyq'
+  command: '{{ conda_env_conda_bin }} clean -tipsyq'
 
 - name: setting up to activate in login shell...
   become: '{{ conda_env_escalate }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,14 +27,12 @@
 - name: '{{ conda_env_action_command }} the conda environment'
   become: '{{ conda_env_escalate }}'
   become_user: root
-  command: '{{ conda_env_conda_bin }} env {{ conda_env_action_command }} --file={{ conda_env_fq_dest_environment }} -q'
+  command: '{{ conda_env_conda_bin }} env {{ conda_env_action_command }} --file={{ conda_env_fq_dest_environment }} -q {% if conda_env_prefix == None %}-n {{ conda_env_name }}{% else %}-p {{conda_env_prefix}}{% endif %}'
   args:
     # pretend task creates nothing to always run when updating an environment. In general, the first directory
     # is where conda creates new environments.
     creates: "{% if conda_env_action_command == 'update' %}{% else %}{{ conda_info.envs_dirs | first }}/{{ conda_env_name }}{% endif %}"
-    # assume the env_dirs is set by conda but allow the it to be overwritten by the user, useful for .venv dirs in projects
-    argv: "{% if conda_env_prefix == None %}'-n {{ conda_env_name }}'{% else %}'-p {{conda_env_prefix}}'{% endif %}"
-
+    
 - name: addl packages...
   become: '{{ conda_env_escalate }}'
   become_user: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     # is where conda creates new environments.
     creates: "{% if conda_env_action_command == 'update' %}{% else %}{{ conda_info.envs_dirs | first }}/{{ conda_env_name }}{% endif %}"
     # assume the env_dirs is set by conda but allow the it to be overwritten by the user, useful for .venv dirs in projects
-    prefix_or_name: "{% if conda_env_prefix == None %}'-n {{ conda_env_name }}'{% else %}'-p {{conda_env_prefix}}'{% endif %}"
+    argv: "{% if conda_env_prefix == None %}'-n {{ conda_env_name }}'{% else %}'-p {{conda_env_prefix}}'{% endif %}"
 
 - name: addl packages...
   become: '{{ conda_env_escalate }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,11 +27,13 @@
 - name: '{{ conda_env_action_command }} the conda environment'
   become: '{{ conda_env_escalate }}'
   become_user: root
-  command: '{{ conda_env_conda_bin }} env {{ conda_env_action_command }} --file={{ conda_env_fq_dest_environment }} -q -n {{ conda_env_name }}'
+  command: '{{ conda_env_conda_bin }} env {{ conda_env_action_command }} --file={{ conda_env_fq_dest_environment }} -q'
   args:
     # pretend task creates nothing to always run when updating an environment. In general, the first directory
     # is where conda creates new environments.
     creates: "{% if conda_env_action_command == 'update' %}{% else %}{{ conda_info.envs_dirs | first }}/{{ conda_env_name }}{% endif %}"
+    # assume the env_dirs is set by conda but allow the it to be overwritten by the user, useful for .venv dirs in projects
+    prefix_or_name: "{% if conda_env_prefix == None %}'-n {{ conda_env_name }}'{% else %}'-p {{conda_env_prefix}}'{% endif %}"
 
 - name: addl packages...
   become: '{{ conda_env_escalate }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: '{{ conda_env_action_command }} the conda environment'
   become: '{{ conda_env_escalate }}'
   become_user: root
-  command: '{{ conda_env_bin_dir }}/conda env {{ conda_env_action_command }} -f={{ conda_env_fq_dest_environment }} -q -n {{ conda_env_name }}'
+  command: '{{ conda_env_bin_dir }}/mamba env {{ conda_env_action_command }} -f={{ conda_env_fq_dest_environment }} -q -n {{ conda_env_name }}'
   args:
     # pretend task creates nothing to always run when updating an environment. In general, the first directory
     # is where conda creates new environments.
@@ -38,13 +38,13 @@
   become_user: root
   when: conda_env_addl_pkgs is defined
   with_items: '{{  conda_env_addl_pkgs | default([])  }}'
-  command: '{{ conda_env_bin_dir }}/conda install -n {{ conda_env_name }} -yq -c {{  item.c | default("defaults")  }} {{  item.p  }}'
+  command: '{{ conda_env_bin_dir }}/mamba install -n {{ conda_env_name }} -yq -c {{  item.c | default("defaults")  }} {{  item.p  }}'
 
-- name: '{{ conda_env_bin_dir }}/conda clean -tipsyq'
+- name: '{{ conda_env_bin_dir }}/mamba clean -tipsyq'
   become: '{{ conda_env_escalate }}'
   become_user: root
   when: conda_env_cleanup
-  command: '{{ conda_env_bin_dir }}/conda clean -tipsyq'
+  command: '{{ conda_env_bin_dir }}/mamba clean -tipsyq'
 
 - name: setting up to activate in login shell...
   become: '{{ conda_env_escalate }}'

--- a/templates/activate.sh.j2
+++ b/templates/activate.sh.j2
@@ -1,1 +1,1 @@
-source {{ conda_env_conda_dir }}/bin/activate {{conda_env_name}}
+source {{ conda_env_conda_dir }}/bin/activate {% if conda_env_prefix == None %}{{ conda_env_name }}{% else %}{{conda_env_prefix}}{% endif %}


### PR DESCRIPTION
Added a variable which allows for the use of prefix, it's mutually exclusive with name so just has it overwrite when used.

Use case:
Name works for the default set up well which installs into env_dirs, prefixes are useful when organizing environments in other locations, for me thats organizing environments within project folders e.g. `/project1/.venv`. Other cases include different envs managed by different groups located in different places. This allows an easy way to choose the destination instead of manipulating the env_dirs.