### PR TITLE
fix: replaced outdated cmdline arguments in conda clean

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,11 +40,11 @@
   with_items: '{{  conda_env_addl_pkgs | default([])  }}'
   command: '{{ conda_env_conda_bin }} install -n {{ conda_env_name }} -yq -c {{  item.c | default("defaults")  }} {{  item.p  }}'
 
-- name: '{{ conda_env_conda_bin }} clean -tipsyq'
+- name: '{{ conda_env_conda_bin }} clean -ayq'
   become: '{{ conda_env_escalate }}'
   become_user: root
   when: conda_env_cleanup
-  command: '{{ conda_env_conda_bin }} clean -tipsyq'
+  command: '{{ conda_env_conda_bin }} clean -ayq'
 
 - block:
     - name: Ansible delete file glob


### PR DESCRIPTION
# Description

Noticed the cleaning task failing with the following error message (debian bullseye, conda 22.11.1): 

```
TASK [ansible-conda-env : /usr/local/anaconda/bin/conda clean -tipsyq] *******************************
fatal: [xxx]: FAILED! => {"changed": true, "cmd": ["/usr/local/anaconda/bin/conda", "clean", "-tipsyq"], 
"delta": "0:00:00.418792", "end": "2022-12-08 14:32:18.117105", "msg": "non-zero return code", 
"rc": 2, "start": "2022-12-08 14:32:17.698313", 
"stderr": "usage: conda clean [-h] [-a] [-i] [-p] [-t] [-f] [-c [TEMPFILES ...]] [-l]\n [-d] [--json] [-q] [-v] [-y]\n
conda clean: error: argument -p/--packages: ignored explicit argument 'syq'", "stderr_lines": 
["usage: conda clean [-h] [-a] [-i] [-p] [-t] [-f] [-c [TEMPFILES ...]] [-l]", "[-d] [--json] [-q] [-v] [-y]", 
"conda clean: error: argument -p/--packages: ignored explicit argument 'syq'"], "stdout": "", "stdout_lines": []}
```

Checked on the respective cmd arguments. Seems like `-s` is not listed in the conda-docs anymore, could not find out clearly when it was dropped. 

# Fix

Replaced the following options:

```
-t, --tarballs
    Remove cached package tarballs.
-i, --index-cache
    Remove index cache.
-p, --packages
    Remove unused packages from writable package caches. WARNING: This does not check for packages installed using symlinks back to the package cache.
-s, --source-cache (deprecated)
    Remove files from the source cache of conda build.
```

by

```
-a, --all
    Remove index cache, lock files, unused cache packages, tarballs, and logfiles.
```

# Tested

Linux debian 5.10.0-19-amd64 #1 SMP Debian 5.10.149-2 (2022-10-21) x86_64 GNU/Linux
conda 22.11.1